### PR TITLE
feat(deps):upgrade libp2p and ipfs-log deps

### DIFF
--- a/example/leveldb_kv/main.go
+++ b/example/leveldb_kv/main.go
@@ -8,7 +8,7 @@ import (
 	iflog "github.com/IceFireDB/icefiredb-ipfs-log"
 	"github.com/IceFireDB/icefiredb-ipfs-log/stores/levelkv"
 	"github.com/abiosoft/ishell/v2"
-	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 	"go.uber.org/zap"
 )
@@ -21,7 +21,7 @@ func main() {
 		panic(err)
 	}
 	// Build host multiaddress
-	hostAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", node.PeerHost.ID().Pretty()))
+	hostAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", node.PeerHost.ID().String()))
 	for _, a := range node.PeerHost.Addrs() {
 		fmt.Println(a.Encapsulate(hostAddr).String())
 	}

--- a/example/loger/main.go
+++ b/example/loger/main.go
@@ -10,8 +10,8 @@ import (
 	ishell "github.com/abiosoft/ishell/v2"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/kubo/core"
-	"github.com/libp2p/go-libp2p-core/host"
-	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -136,7 +136,7 @@ func addCmd(ctx context.Context, shell *ishell.Shell, node *core.IpfsNode, ev *i
 
 func PrintHostAddress(ha host.Host) {
 	// Build host multiaddress
-	hostAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", ha.ID().Pretty()))
+	hostAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", ha.ID().String()))
 
 	// Now we can build a full multiaddress to reach this host
 	// by encapsulating both addresses:


### PR DESCRIPTION
### Upgrade libp2p and ipfs-log dependencies

This commit upgrades the dependencies for libp2p and ipfs-log to their latest versions. The update includes bug fixes, performance improvements, and compatibility enhancements, ensuring our project remains aligned with the latest features and improvements in these libraries. This upgrade enhances stability and functionality.

**Changes:**
- Updated libp2p to version 0.33.2
- Updated berty.tech/go-ipfs-logto version 0.10.2

**Impact:**
- Bug fixes and performance improvements
- Compatibility enhancements
- Improved stability and functionality
